### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,4 +26,8 @@
   <run_depend>graphviz</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>


### PR DESCRIPTION
This package doesn't have any binaries in it, so it can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
