### PR TITLE
fix read_number

### DIFF
--- a/src/xdot/xdot.py
+++ b/src/xdot/xdot.py
@@ -477,7 +477,7 @@ class XDotAttrParser:
         return res
 
     def read_number(self):
-        return int(self.read_code())
+        return int(float(self.read_code()))
 
     def read_float(self):
         return float(self.read_code())

--- a/src/xdot/xdot_qt.py
+++ b/src/xdot/xdot_qt.py
@@ -508,7 +508,7 @@ class XDotAttrParser:
         return res
 
     def read_number(self):
-        return int(self.read_code())
+        return int(float(self.read_code()))
 
     def read_float(self):
         return float(self.read_code())


### PR DESCRIPTION
direct conversion from string containing a float to int doesn't work, a detour to float is needed

(see also http://answers.ros.org/question/172688/ros-indigo-cannot-show-graph-view-on-smach_viewer/)
