### PR TITLE
use read_int or read_float, instead of read_number

### DIFF
--- a/src/xdot/xdot.py
+++ b/src/xdot/xdot.py
@@ -476,19 +476,19 @@ class XDotAttrParser:
             self.pos += 1
         return res
 
-    def read_number(self):
-        return int(float(self.read_code()))
+    def read_int(self):
+        return int(self.read_code())
 
     def read_float(self):
         return float(self.read_code())
 
     def read_point(self):
-        x = self.read_number()
-        y = self.read_number()
+        x = self.read_float()
+        y = self.read_float()
         return self.transform(x, y)
 
     def read_text(self):
-        num = self.read_number()
+        num = self.read_int()
         pos = self.buf.find("-", self.pos) + 1
         self.pos = pos + num
         res = self.buf[pos:self.pos]
@@ -497,7 +497,7 @@ class XDotAttrParser:
         return res
 
     def read_polygon(self):
-        n = self.read_number()
+        n = self.read_int()
         p = []
         for i in range(n):
             x, y = self.read_point()
@@ -584,19 +584,19 @@ class XDotAttrParser:
                 self.handle_font(size, name)
             elif op == "T":
                 x, y = s.read_point()
-                j = s.read_number()
-                w = s.read_number()
+                j = s.read_int()
+                w = s.read_float()
                 t = s.read_text()
                 self.handle_text(x, y, j, w, t)
             elif op == "E":
                 x0, y0 = s.read_point()
-                w = s.read_number()
-                h = s.read_number()
+                w = s.read_float()
+                h = s.read_float()
                 self.handle_ellipse(x0, y0, w, h, filled=True)
             elif op == "e":
                 x0, y0 = s.read_point()
-                w = s.read_number()
-                h = s.read_number()
+                w = s.read_float()
+                h = s.read_float()
                 self.handle_ellipse(x0, y0, w, h, filled=False)
             elif op == "L":
                 points = self.read_polygon()

--- a/src/xdot/xdot_qt.py
+++ b/src/xdot/xdot_qt.py
@@ -414,19 +414,19 @@ class XDotAttrParser:
             self.pos += 1
         return res
 
-    def read_number(self):
-        return int(float(self.read_code()))
+    def read_int(self):
+        return int(self.read_code())
 
     def read_float(self):
         return float(self.read_code())
 
     def read_point(self):
-        x = self.read_number()
-        y = self.read_number()
+        x = self.read_float()
+        y = self.read_float()
         return self.transform(x, y)
 
     def read_text(self):
-        num = self.read_number()
+        num = self.read_int()
         pos = self.buf.find("-", self.pos) + 1
         self.pos = pos + num
         res = self.buf[pos:self.pos]
@@ -435,7 +435,7 @@ class XDotAttrParser:
         return res
 
     def read_polygon(self):
-        n = self.read_number()
+        n = self.read_int()
         p = []
 #        p = QPointF[]
         for i in range(n):
@@ -524,19 +524,19 @@ class XDotAttrParser:
                 self.handle_font(size, name)
             elif op == "T":
                 x, y = s.read_point()
-                j = s.read_number()
-                w = s.read_number()
+                j = s.read_int()
+                w = s.read_float()
                 t = s.read_text()
                 self.handle_text(x, y, j, w, t)
             elif op == "E":
                 x0, y0 = s.read_point()
-                w = s.read_number()
-                h = s.read_number()
+                w = s.read_float()
+                h = s.read_float()
                 self.handle_ellipse(x0, y0, w, h, filled=True)
             elif op == "e":
                 x0, y0 = s.read_point()
-                w = s.read_number()
-                h = s.read_number()
+                w = s.read_float()
+                h = s.read_float()
                 self.handle_ellipse(x0, y0, w, h, filled=False)
             elif op == "L":
                 points = self.read_polygon()


### PR DESCRIPTION
https://github.com/jbohren/xdot/commit/669917e6670779c03835b12db77dacdfac78ea36 is ok for workaround of https://github.com/ros-visualization/executive_smach_visualization/issues/7, but from 
https://github.com/jrfonseca/xdot.py/commit/e36b49b2b0b5038515bd4479fe119d92d3e2719d
I think this pr is more precise.
