### PR TITLE
revert necessary imports

### DIFF
--- a/src/xdot/__init__.py
+++ b/src/xdot/__init__.py
@@ -1,0 +1,3 @@
+
+import wxxdot
+import xdot_qt


### PR DESCRIPTION
as reported on #8, https://github.com/jbohren/xdot/commit/7ce3355b95ce583086c9649ce0de0db54a9317c6 was wrong commit, this breaks all functionality, so this PR is required to run smach_viewer.py
